### PR TITLE
Server d2 leaderboard

### DIFF
--- a/public/scripts/model/app.js
+++ b/public/scripts/model/app.js
@@ -34,7 +34,7 @@ var app = app || {};
         if(this.vanityUrl.length !== 17 || isNaN(Number(this.vanityUrl))) return false
 
         this.steamId = this.vanityUrl
-        delete this.vanityUrl
+        this.vanityUrl = ''
         return this
       })
 

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ app.get('/api/v1/leaderboard', (req, res) =>{
 
 app.post('/api/v1/leaderboard', bodyParser, (req, res) => {
   console.log('Hit POST /leaderboard')
-  client.query(`INSERT INTO leaderboard(name, hours) VALUES('${req.body.name}', ${req.body.hours})`)
+  client.query(`INSERT INTO leaderboard(steamid, hours, vanity) VALUES(${req.body.steamid}, ${req.body.hours}, '${req.body.vanity}')`)
     .then(() => res.send('Insert Successful.'))
     .catch( err => console.log(err))
 })

--- a/server.js
+++ b/server.js
@@ -52,7 +52,14 @@ app.get('/api/v1/leaderboard', (req, res) =>{
 
 app.post('/api/v1/leaderboard', bodyParser, (req, res) => {
   console.log('Hit POST /leaderboard')
-  client.query(`INSERT INTO leaderboard(steamid, hours, vanity) VALUES(${req.body.steamid}, ${req.body.hours}, '${req.body.vanity}')`)
+  client.query(`
+    INSERT INTO leaderboard(steamid, hours, vanity)
+    VALUES(${req.body.steamid}, ${req.body.hours}, '${req.body.vanity}') 
+    ON CONFLICT (steamid) DO UPDATE
+      SET
+       hours=${req.body.hours},
+       vanity='${req.body.vanity}'
+    `)
     .then(() => res.send('Insert Successful.'))
     .catch( err => console.log(err))
 })

--- a/server.js
+++ b/server.js
@@ -42,12 +42,25 @@ app.get('/api/v1/steamers/:id', (req, res) =>{
 })
 
 // --------------- Leaderboard Endpoints ----------------
-
+// Gets all users
 app.get('/api/v1/leaderboard', (req, res) =>{
   console.log('Hit GET /leaderboard.')
-  client.query('SELECT * FROM leaderboard')
+  client.query(`SELECT * FROM leaderboard WHERE vanity NOT IN ('')`)
     .then( data => res.send(data.rows))
-    .catch( err => console.log(err))
+    .catch( err => {
+      res.send('No leaderboard yet')
+      console.log(err)
+    })
+})
+
+app.get('/api/v1/leaderboard/:steamid', (req, res) => {
+  console.log(`Hit Get /leaderboard/:${req.params.steamid}`)
+  client.query(`select * from leaderboard where steamid = '${req.params.steamid}'`)
+    .then( result => res.send(result.rows))
+    .catch( err => {
+      res.send('No match')
+      console.log(err)
+    })
 })
 
 app.post('/api/v1/leaderboard', bodyParser, (req, res) => {


### PR DESCRIPTION
Updated server to include routes for getting all, getting one, and posting to the leaderboard.


Notes: 
Currently not sure about the best approach for the post route. Since we only want unique users in the database, when a user enters a name it will currently post that user to the database if it doesn't exists. If it does, meaning on conflict, it will instead update that user's hours and vanity name if they changed. Not sure if I should break that into two routes, a true post and a patch/put, or leave as is since this reduces the need to make a subsequent request if the user already  exists in the db. 

In the end I will be for sure separating this out to make it a full CRUD api anyways, so it's fine for now.