### PR TITLE
 Mostly just minor changes. app.Steamer is the constructor attached t…

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <section id="home-view" class="page">
       <h2>home-view</h2>
       <form id="search-steamer">
-        <label for="steamer">Search for a Steamer:<input type="text" name="steamer"><button type="submit">Submit</button></label>
+        <label for="steamer">Search for a Steamer:<input type="text" name="steamer" placeholder="KillerTreat" autofocus><button type="submit">Submit</button></label>
         <p id="invalid-user-error" class="error">Sorry, no results for that user. Enter either your Steam Id or your Vanity Url!</p>
       </form>
 

--- a/public/scripts/controller/routes.js
+++ b/public/scripts/controller/routes.js
@@ -1,10 +1,15 @@
 'use strict'
 /* global page, app */
 
-page('/', app.HomeView.initHomeView, app.ShameView.initShameView, app.ShameView.calculateShame)
+if(window.location.pathname !== '/') page.base(window.location.pathname)
 
-page('/steamer', app.ShameView.initShameView, app.ShameView.calculateShame)
+page('/', app.homeView.initHomeView, app.shameView.initShameView, app.shameView.calculateShame)
 
-page('/games', app.GamesView.initGamesView)
+page('/steamer', app.shameView.initShameView, app.shameView.calculateShame)
+
+page('/games', app.gamesView.initGamesView)
+
+page('*', app.homeView.initHomeView)
 
 page()
+

--- a/public/scripts/model/app.js
+++ b/public/scripts/model/app.js
@@ -12,7 +12,7 @@ var app = app || {};
       this.hours = hours
       this.games = games
       this.rank = 'No position yet!'
-      this.steamer = this
+      app.steamer = this
       return this
     }
 
@@ -35,7 +35,7 @@ var app = app || {};
         .then( potentialSteamId => {
           if(potentialSteamId) return this.getUserData(ctx, next)
 
-          delete app.Steamer.steamer
+          delete app.steamer
           return app.homeView.errorInvalidSteamer()
         })
         .catch( err => console.log(err))
@@ -50,7 +50,7 @@ var app = app || {};
 
           results = JSON.parse(results.text)
           this.gameData = results.response
-          this.games = this.gameData.games
+          this.games = this.gameData.games || []
           this.gamesCount = this.gameData.game_count
           return this
 
@@ -63,7 +63,7 @@ var app = app || {};
     }
 
     calcHours(ctx,next){
-      this.hours = this.games.map( game => game.playtime_forever).reduce( (hour, cum) => cum += hour, 0 ) / 60
+      this.hours = this.games.map( game => game.playtime_forever).reduce( (hour, curr) => curr += hour, 0 ) / 60
       this.wage = this.hours * 15
       ctx.steamer = this
       localStorage.steamer = JSON.stringify(this)

--- a/public/scripts/view/about-view.js
+++ b/public/scripts/view/about-view.js
@@ -11,5 +11,5 @@ var app = app || {};
       $('#about-view').show()
     }
   }
-  app.AboutView = new AboutView()
+  app.aboutView = new AboutView()
 }

--- a/public/scripts/view/games-view.js
+++ b/public/scripts/view/games-view.js
@@ -11,33 +11,33 @@ var app = app || {};
       $('.page').hide()
       $('#games-view').show()
 
-      if(!app.Steamer.steamer) return app.GamesView.errorNoSteamer()
-      GamesView.renderGamesList()
+      if(!app.steamer) return app.gamesView.errorNoSteamer()
+      app.gamesView.renderGamesList()
     }
 
     errorNoSteamer(){
       if(!localStorage.steamer) return $('#game-nouser-error').show()
 
-      let s = JSON.parse(localStorage.steamer)
-      new app.Steamer(s.vanityUrl, s.steamId, s.hours, s.games)
-
+      let { vanityUrl, steamId, hours, games } = JSON.parse(localStorage.steamer)
+      new app.Steamer(vanityUrl, steamId, hours, games)
+     
       // Add the cached flag to trigger warnings so the user know this is only a cached version.
-      app.Steamer.steamer.cached = true
-      GamesView.renderGamesList()
+      app.steamer.cached = true
+      app.gamesView.renderGamesList()
     }
 
     renderGamesList(){
-      if(app.Steamer.steamer.cached) $('#game-localuser-error').show()
-      if(GamesView.alreadyRendered) return // prevents duplicating the page.
+      if(app.steamer.cached) $('#game-localuser-error').show()
+      if(app.gamesView.alreadyRendered) return // prevents duplicating the page.
 
-      GamesView.alreadyRendered = true;
+      app.gamesView.alreadyRendered = true;
       let template = Handlebars.compile($('#game-details-template').text());
-      app.Steamer.steamer.games.map( game => {
+      app.steamer.games.map( game => {
         $('#games-list').append(template(game))
       })
     }
   }
 
-  GamesView.alreadyRendered = false;
-  app.GamesView = new GamesView()
+  app.gamesView = new GamesView()
+  app.gamesView.alreadyRendered = false;
 }

--- a/public/scripts/view/help-view.js
+++ b/public/scripts/view/help-view.js
@@ -11,5 +11,5 @@ var app = app || {};
     }
   }
 
-  app.HelpView = new HelpView()
+  app.helpView = new HelpView()
 }

--- a/public/scripts/view/home-view.js
+++ b/public/scripts/view/home-view.js
@@ -27,5 +27,5 @@ var app = app || {};
     }
   }
 
-  app.HomeView = new HomeView()
+  app.homeView = new HomeView()
 }

--- a/public/scripts/view/leaderboard-view.js
+++ b/public/scripts/view/leaderboard-view.js
@@ -12,5 +12,5 @@ var app = app || {};
     }
   }
 
-  app.LeaderboardView = new LeaderboardView()
+  app.leaderboardView = new LeaderboardView()
 }

--- a/public/scripts/view/shame-view.js
+++ b/public/scripts/view/shame-view.js
@@ -10,31 +10,31 @@ var app = app || {};
       $('.page').hide()
       $('#shame-view').show()
 
-      if(!app.Steamer.steamer) return app.ShameView.errorNoSteamer()
-      ShameView.renderShame()
+      if(!app.steamer) return app.shameView.errorNoSteamer()
+      app.shameView.renderShame()
     }
 
     errorNoSteamer() {
       if(!localStorage.steamer) return $('#shame-nouser-error').show()
-
-      let s = JSON.parse(localStorage.steamer)
-      new app.Steamer(s.vanityUrl, s.steamId, s.hours, s.games)
+      
+      let {vanityUrl, steamId, hours, games} = JSON.parse(localStorage.steamer)
+      new app.Steamer(vanityUrl, steamId, hours, games)
 
       // Add the cached flag to trigger warning for the user that this is just the cached version.
-      app.Steamer.steamer.cached = true
-      ShameView.renderShame()
+      app.steamer.cached = true
+      app.shameView.renderShame()
     }
 
     renderShame() {
-      if(app.Steamer.steamer.cached) $('#shame-localuser-error').show()
+      if(app.steamer.cached) $('#shame-localuser-error').show()
       if(ShameView.alreadyRendered) return
 
-      ShameView.alreadyRendered = true
+      app.shameView.alreadyRendered = true
       let template = Handlebars.compile($('#shame-template').text())
-      $('#shame-view').append(template(app.Steamer.steamer))
+      $('#shame-view').append(template(app.steamer))
     }
   }
 
-  ShameView.alreadyRendered = false;
-  app.ShameView = new ShameView()
+  app.shameView = new ShameView()
+  app.shameView.alreadyRendered = false;
 }


### PR DESCRIPTION
…o app, and app.steamer is the current steamer that is made from that constructor. The views however are not constructors. When they are attached to the app, they are attached as a view. Thus I updated the names of the views to bring them back to camelCase instead of PascelCase. Also testing out a deployment fix by setting the base path in Page.js Locally the pathname is '/', but deployed on github it is the name of the repo, then the '/'. Still need to factor in the history api and get the leaderboard and help page working, but this was a good mini update session.